### PR TITLE
Avoid FOUC with FastBoot

### DIFF
--- a/addon/instance-initializers/hydrate-fastboot-styles.js
+++ b/addon/instance-initializers/hydrate-fastboot-styles.js
@@ -1,0 +1,19 @@
+import { get } from '@ember/object';
+import { hydrate } from 'emotion';
+
+export const FASTBOOT_STYLE_CACHE_NAME = 'emotion-ids';
+
+export function initialize(appInstance) {
+  const fastboot = appInstance.lookup('service:fastboot');
+
+  if (fastboot && !get(fastboot, 'isFastBoot')) {
+    const shoebox = get(fastboot, 'shoebox');
+    const emotionIds = shoebox.retrieve(FASTBOOT_STYLE_CACHE_NAME);
+
+    hydrate(emotionIds);
+  }
+}
+
+export default {
+  initialize
+};

--- a/addon/mixins/resolver.js
+++ b/addon/mixins/resolver.js
@@ -18,7 +18,14 @@ export default Mixin.create({
     try {
       return require(moduleName, null, null, true);
     } catch (e) {
-      return {};
+      if (
+        e.message ===
+        'Could not find module `undefined` imported from `(require)`'
+      ) {
+        return {};
+      }
+
+      throw e;
     }
   }
 });

--- a/app/instance-initializers/hydrate-fastboot-styles.js
+++ b/app/instance-initializers/hydrate-fastboot-styles.js
@@ -1,0 +1,4 @@
+export {
+  default,
+  initialize
+} from 'ember-emotion/instance-initializers/hydrate-fastboot-styles';

--- a/fastboot/instance-initializers/setup-style-cache.js
+++ b/fastboot/instance-initializers/setup-style-cache.js
@@ -12,7 +12,10 @@ export function initialize(application) {
   // Generate the styles that we need to inject into the page
   scheduleOnce('afterRender', function() {
     const style = document.createElement('style');
-    const css = emotion.sheet.sheet.reduce((acc, style) => acc + style, '');
+    const css = Object.values(emotion.caches.inserted).reduce(
+      (acc, style) => acc + style,
+      ''
+    );
 
     style.type = 'text/css';
     if (style.styleSheet) {
@@ -22,7 +25,10 @@ export function initialize(application) {
     }
 
     // Put IDs into showboe for re-hydration
-    shoebox.put(FASTBOOT_STYLE_CACHE_NAME, Object.keys(emotion.inserted));
+    shoebox.put(
+      FASTBOOT_STYLE_CACHE_NAME,
+      Object.keys(emotion.caches.inserted)
+    );
 
     document.head.appendChild(style);
   });

--- a/fastboot/instance-initializers/setup-style-cache.js
+++ b/fastboot/instance-initializers/setup-style-cache.js
@@ -1,0 +1,33 @@
+import { scheduleOnce } from '@ember/runloop';
+import { get } from '@ember/object';
+import emotion from 'emotion';
+
+import { FASTBOOT_STYLE_CACHE_NAME } from 'ember-emotion/instance-initializers/hydrate-fastboot-styles';
+
+export function initialize(application) {
+  const document = application.lookup('service:-document');
+  const fastboot = application.lookup('service:fastboot');
+  const shoebox = get(fastboot, 'shoebox');
+
+  // Generate the styles that we need to inject into the page
+  scheduleOnce('afterRender', function() {
+    const style = document.createElement('style');
+    const css = emotion.sheet.sheet.reduce((acc, style) => acc + style, '');
+
+    style.type = 'text/css';
+    if (style.styleSheet) {
+      style.styleSheet.cssText = css;
+    } else {
+      style.appendChild(document.createTextNode(css));
+    }
+
+    // Put IDs into showboe for re-hydration
+    shoebox.put(FASTBOOT_STYLE_CACHE_NAME, Object.keys(emotion.inserted));
+
+    document.head.appendChild(style);
+  });
+}
+
+export default {
+  initialize
+};

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "babel-plugin-emotion": "^8.0.12",
+    "babel-plugin-emotion": "9.0.0-3",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^2.0.0",
     "ember-cli-babel": "^6.6.0",
     "ember-cli-version-checker": "^2.1.0",
-    "emotion": "^8.0.12",
+    "emotion": "9.0.0-3",
     "semver": "^5.4.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "node": "^4.5 || 6.* || >= 7.*"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "demoURL": "http://alexlafroscia.com/ember-emotion"
   }
 }

--- a/tests/integration/components/pod-styles-js-test.js
+++ b/tests/integration/components/pod-styles-js-test.js
@@ -35,7 +35,7 @@ test('it exposes other exports as properties', function(assert) {
 
 test('it strips whitespacing', function(assert) {
   assert.equal(
-    emotion.registered[excessiveWhitespaceClass],
+    emotion.caches.registered[excessiveWhitespaceClass],
     'background-color:grey;padding:1em;'
   );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -511,12 +511,6 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-macros@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/babel-macros/-/babel-macros-1.2.0.tgz#39e47ed6d286d4a98f1948d8bab45dac17e4e2d4"
-  dependencies:
-    cosmiconfig "3.1.0"
-
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
@@ -549,15 +543,15 @@ babel-plugin-ember-modules-api-polyfill@^2.3.0:
   dependencies:
     ember-rfc176-data "^0.3.0"
 
-babel-plugin-emotion@^8.0.12:
-  version "8.0.12"
-  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-8.0.12.tgz#2ed844001416b0ae2ff787a06b1804ec5f531c89"
+babel-plugin-emotion@9.0.0-3, babel-plugin-emotion@^9.0.0-3:
+  version "9.0.0-3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-9.0.0-3.tgz#4a2293911c79b6cbea1c822e7ce7bb4635bc12d0"
   dependencies:
     "@babel/helper-module-imports" "7.0.0-beta.32"
-    babel-macros "^1.2.0"
+    babel-plugin-macros "^2.0.0"
     babel-plugin-syntax-jsx "^6.18.0"
     convert-source-map "^1.5.0"
-    emotion-utils "^8.0.12"
+    emotion-utils "^9.0.0-3"
     find-root "^1.1.0"
     source-map "^0.5.7"
     touch "^1.0.0"
@@ -577,6 +571,12 @@ babel-plugin-inline-environment-variables@^1.0.1:
 babel-plugin-jscript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz#8f342c38276e87a47d5fa0a8bd3d5eb6ccad8fcc"
+
+babel-plugin-macros@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.1.0.tgz#e978fd4c5ee9cca73a809c176524c2e9f4dcccbf"
+  dependencies:
+    cosmiconfig "^4.0.0"
 
 babel-plugin-member-expression-literals@^1.0.1:
   version "1.0.1"
@@ -1853,14 +1853,22 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cosmiconfig@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-3.1.0.tgz#640a94bf9847f321800403cd273af60665c73397"
+cosmiconfig@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-4.0.0.tgz#760391549580bbd2df1e562bc177b13c290972dc"
   dependencies:
     is-directory "^0.3.1"
     js-yaml "^3.9.0"
-    parse-json "^3.0.0"
+    parse-json "^4.0.0"
     require-from-string "^2.0.1"
+
+create-emotion@^9.0.0-3:
+  version "9.0.0-3"
+  resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-9.0.0-3.tgz#875ab6a35325c3d6fe2f19edfa168d2e1ad04cf0"
+  dependencies:
+    emotion-utils "^9.0.0-3"
+    stylis "^3.3.2"
+    stylis-rule-sheet "^0.0.5"
 
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
@@ -2477,18 +2485,16 @@ ember-try@^0.2.15:
     rsvp "^3.0.17"
     semver "^5.1.0"
 
-emotion-utils@^8.0.12:
-  version "8.0.12"
-  resolved "https://registry.yarnpkg.com/emotion-utils/-/emotion-utils-8.0.12.tgz#5e0fd72db3008f26ce4f80b1972df08841df2168"
+emotion-utils@^9.0.0-3:
+  version "9.0.0-3"
+  resolved "https://registry.yarnpkg.com/emotion-utils/-/emotion-utils-9.0.0-3.tgz#34acff4f47dfa753a67d006398bafbe9e4369f14"
 
-emotion@^8.0.12:
-  version "8.0.12"
-  resolved "https://registry.yarnpkg.com/emotion/-/emotion-8.0.12.tgz#03de11ce26b1b2401c334b94d438652124c514c6"
+emotion@9.0.0-3:
+  version "9.0.0-3"
+  resolved "https://registry.yarnpkg.com/emotion/-/emotion-9.0.0-3.tgz#abe6d4c8c44fdae7eda1da8594c0f91eebeb64d5"
   dependencies:
-    babel-plugin-emotion "^8.0.12"
-    emotion-utils "^8.0.12"
-    stylis "^3.3.2"
-    stylis-rule-sheet "^0.0.5"
+    babel-plugin-emotion "^9.0.0-3"
+    create-emotion "^9.0.0-3"
 
 encodeurl@~1.0.1:
   version "1.0.1"
@@ -3742,6 +3748,10 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
+json-parse-better-errors@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz#50183cd1b2d25275de069e9e71b467ac9eab973a"
+
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
@@ -4722,11 +4732,12 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
-parse-json@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-3.0.0.tgz#fa6f47b18e23826ead32f263e744d0e1e847fb13"
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
   dependencies:
     error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
 
 parse-passwd@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Without explicit FastBoot support, the content would come down rendered from the server but no styles would be present yet. This caused an issue called "flash of unstyled content", or FOUC, that is common with server-side-rendered JavaScript apps that use CSS-in-JS solutions.

This PR introduces proper FastBoot support.  The styles required for the initial render are computed on the server and baked into the initial payload, so that they're ready when the content is rendered by the browser. `emotion` is also "hydrated" with these styles, so that it avoids injecting them into the page a second time.

The technical approach to these things leans heavily on the patterns established by the first-party React SSR support, so I feel confident that I'm not using APIs that will break in the near future.

Additionally, `emotion` has an issue with the FastBoot environment that I landed emotion-js/emotion#550 to fix. This PR (once merged) will reference a version of `emotion` that includes that change.

## TODOs

- [x] Update to `emotion` version `9.0.0-3` (or later)
- [ ] Add some smoke tests for FastBoot to ensure that the server-side rendering doesn't break without me noticing
  - Probably can't test that the re-hydration works, but can at least test that the initial payload includes the CSS that's expected

Closes #2